### PR TITLE
Fix `this.container` resolving to `"(unknown mixin)"`

### DIFF
--- a/addon/mixins/localizable.js
+++ b/addon/mixins/localizable.js
@@ -9,8 +9,7 @@ export default function(translations) {
     init() {
       this._super(...arguments);
 
-      const localizablePrefix = this.constructor
-        .toString()
+      const localizablePrefix = (this._debugContainerKey || '')
         .split(':')
         .filter((segment) => !!segment)
         .pop();


### PR DESCRIPTION
In newer versions of Ember `this.container` resolves to `"(unknown mixin)"` so the last component defined was overriding the translations for all the others.

Now we rely on `_debugContainerKey` which is the technique used by `ember-component-css`