### PR TITLE
Add “License” section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,14 @@ $ ember build
 ```
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
+
+## License
+
+`ember-cli-pod-translations` is © 2017 [Mirego](http://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).
+See the [`LICENSE.md`](https://github.com/mirego/ember-cli-pod-translations/blob/master/LICENSE.md) file.
+
+## About Mirego
+
+[Mirego](http://mirego.com) is a team of passionate people who believe that work is a place where you can innovate and have fun. We're a team of [talented people](http://life.mirego.com) who imagine and build beautiful Web and mobile applications. We come together to share ideas and [change the world](http://mirego.org).
+
+We also [love open-source software](http://open.mirego.com) and we try to give back to the community as much as we can.


### PR DESCRIPTION
We were missing the universal Mirego “License” section 😄 